### PR TITLE
🔥 remove a breakpoint in diagnosis generator

### DIFF
--- a/cds/generator/diagnosis/build_manifest.py
+++ b/cds/generator/diagnosis/build_manifest.py
@@ -189,7 +189,6 @@ def build_diagnosis_table(
         if p not in histology_diagnosis["participant_id"].to_list()
     ]
     missing_diagnoses = find_missing_diagnoses(missing_participants, fsp, conn)
-    # breakpoint()
     combined_diagnoses = pd.concat([histology_diagnosis, missing_diagnoses])
     combined_diagnoses["diagnosis_id"] = (
         "DG__" + combined_diagnoses["sample_id"]


### PR DESCRIPTION
# 🔥 remove a breakpoint in diagnosis generator

- [ ] closes #xxxx
- [ ] README entry added if new functionality
- [ ] fixup commits are appropriately squashed
- [ ] submission_packet has been regenerated and committed as last commit in this PR

removes a breakpoint that was in the diagnosis manifest generator
