### PR TITLE
🧑‍💻 order columns in the output manifests by default

### DIFF
--- a/cds/generator/diagnosis/build_manifest.py
+++ b/cds/generator/diagnosis/build_manifest.py
@@ -206,6 +206,23 @@ def find_missing_diagnoses(participants_missing_diagnoses, fsp, conn):
     return missing_diagnoses
 
 
+def order_columns(manifest):
+    """order columns in the manifest
+
+    :param manifest: The manifest to order columns for
+    :type manifest: pandas.DataFrame
+    :return: The manifest with columns needed in the correct order
+    :rtype: pandas.DataFrame
+    """
+    columns = [
+        "diagnosis_id",
+        "primary_diagnosis",
+        "participant_id",
+        "disease_type",
+    ]
+    return manifest[columns]
+
+
 def build_diagnosis_table(
     db_url,
     sample_list,
@@ -291,6 +308,8 @@ def build_diagnosis_table(
         how="left",
         on="primary_diagnosis",
     ).dropna(subset=["primary_diagnosis"])
+
+    diagnoses_manifest = order_columns(diagnoses_manifest)
     diagnoses_manifest.to_csv(
         f"{submission_package_dir}diagnosis.csv", index=False
     )

--- a/cds/generator/file/build_manifest.py
+++ b/cds/generator/file/build_manifest.py
@@ -11,6 +11,26 @@ import psycopg2
 logger = get_logger(__name__, testing_mode=False)
 
 
+def order_columns(manifest):
+    """order columns in the manifest
+
+    :param manifest: The manifest to order columns for
+    :type manifest: pandas.DataFrame
+    :return: The manifest with columns needed in the correct order
+    :rtype: pandas.DataFrame
+    """
+    columns = [
+        "file_id",
+        "file_name",
+        "file_type",
+        "file_size",
+        "md5sum",
+        "file_url_in_cds",
+        "controlled_access",
+    ]
+    return manifest[columns]
+
+
 def build_file_table(db_url, file_list, submission_package_dir):
     logger.info("Building file table")
     logger.info("connecting to database")

--- a/cds/generator/genomic_info/build_manifest.py
+++ b/cds/generator/genomic_info/build_manifest.py
@@ -72,6 +72,33 @@ def get_file_genomes(file_list, conn):
     return genomes_ds[["file_id", "reference_genome_assembly"]]
 
 
+def order_columns(manifest):
+    """order columns in the manifest
+
+    :param manifest: The manifest to order columns for
+    :type manifest: pandas.DataFrame
+    :return: The manifest with columns needed in the correct order
+    :rtype: pandas.DataFrame
+    """
+    columns = [
+        "sample_id",
+        "file_id",
+        "bases",
+        "number_of_reads",
+        "coverage",
+        "avg_read_length",
+        "insert_size",
+        "platform",
+        "instrument_model",
+        "library_source",
+        "library_strategy",
+        "library_layout",
+        "reference_genome_assembly",
+        "library_id",
+    ]
+    return manifest[columns]
+
+
 def build_genomic_info_table(
     db_url, file_sample_participant_map, submission_package_dir
 ):
@@ -104,6 +131,7 @@ def build_genomic_info_table(
     genomic_info["library_id"] = (
         genomic_info["sample_id"] + "__" + genomic_info["file_id"]
     )
+    genomic_info = order_columns(genomic_info)
     genomic_info.to_csv(
         f"{submission_package_dir}/genomic_info.csv", index=False
     )

--- a/cds/generator/participant/build_manifest.py
+++ b/cds/generator/participant/build_manifest.py
@@ -9,6 +9,23 @@ import psycopg2
 logger = get_logger(__name__, testing_mode=False)
 
 
+def order_columns(manifest):
+    """order columns in the manifest
+
+    :param manifest: The manifest to order columns for
+    :type manifest: pandas.DataFrame
+    :return: The manifest with columns needed in the correct order
+    :rtype: pandas.DataFrame
+    """
+    columns = [
+        "participant_id",
+        "gender",
+        "race",
+        "ethnicity",
+    ]
+    return manifest[columns]
+
+
 def build_participant_table(db_url, participant_list, submission_package_dir):
     logger.info("Building participant table")
     logger.info("connecting to database")
@@ -27,7 +44,8 @@ def build_participant_table(db_url, participant_list, submission_package_dir):
     participant_table["ethnicity"] = participant_table["ethnicity"].apply(
         lambda x: ethnicity_map.get(x)
     )
-    logger.info("saving sample manifest to file")
+    participant_table = order_columns(participant_table)
+    logger.info("saving participant manifest to file")
     participant_table.to_csv(
         f"{submission_package_dir}/participant.csv", index=False
     )

--- a/cds/generator/sample/build_manifest.py
+++ b/cds/generator/sample/build_manifest.py
@@ -9,6 +9,25 @@ import psycopg2
 logger = get_logger(__name__, testing_mode=False)
 
 
+def order_columns(manifest):
+    """order columns in the manifest
+
+    :param manifest: The manifest to order columns for
+    :type manifest: pandas.DataFrame
+    :return: The manifest with columns needed in the correct order
+    :rtype: pandas.DataFrame
+    """
+    columns = [
+        "sample_id",
+        "sample_type",
+        "participant_id",
+        "sample_tumor_status",
+        "sample_anatomical_site",
+        "sample_age_at_collection",
+    ]
+    return manifest[columns]
+
+
 def build_sample_table(db_url, sample_list, submission_package_dir):
     logger.info("Building sample table")
     logger.info("connecting to database")


### PR DESCRIPTION
# 🧑‍💻 order columns in the output manifests

- [ ] closes #xxxx
- [ ] README entry added if new functionality
- [ ] fixup commits are appropriately squashed
- [x] submission_packet has been regenerated and committed as last commit in this PR


