### PR TITLE
🐛 file id comes before sample in genomic_info

### DIFF
--- a/cds/generator/genomic_info/build_manifest.py
+++ b/cds/generator/genomic_info/build_manifest.py
@@ -81,8 +81,8 @@ def order_columns(manifest):
     :rtype: pandas.DataFrame
     """
     columns = [
-        "sample_id",
         "file_id",
+        "sample_id",
         "bases",
         "number_of_reads",
         "coverage",


### PR DESCRIPTION
# 🐛 file id comes before sample in genomic_info

- [ ] closes #xxxx
- [ ] README entry added if new functionality
- [ ] fixup commits are appropriately squashed
- [x] submission_packet has been regenerated and committed as last commit in this PR

per @baileyckelly file id comes before sample id in the genomic_info table
