### PR TITLE
🔧 ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 # data
 */data
 *.csv
+
+# Macos Desktop Store
+*.DS_Store


### PR DESCRIPTION
# 🔧 ignore .DS_Store files

- [ ] closes #xxxx
- [ ] README entry added if new functionality
- [ ] fixup commits are appropriately squashed
- [ ] submission_packet has been regenerated and committed as last commit in this PR

Ignore .DS_Store files in gitignore. 