### PR TITLE
📝 add docstrings for build_manifest functions

### DIFF
--- a/cds/generator/file/build_manifest.py
+++ b/cds/generator/file/build_manifest.py
@@ -30,6 +30,19 @@ def order_columns(manifest):
 
 
 def build_file_table(db_url, file_list, submission_package_dir):
+    """Build the file table
+
+    Build the file manifest
+
+    :param db_url: database url to KF prd postgres
+    :type db_url: str
+    :param file_list: file IDs to have in the file manifest
+    :type file_list: list
+    :param submission_package_dir: directory to save the output manifest
+    :type submission_package_dir: str
+    :return: file table
+    :rtype: pandas.DataFrame
+    """
     logger.info("Building file table")
     logger.info("connecting to database")
     conn = psycopg2.connect(db_url)

--- a/cds/generator/genomic_info/build_manifest.py
+++ b/cds/generator/genomic_info/build_manifest.py
@@ -111,6 +111,8 @@ def build_genomic_info_table(
     :type file_sample_participant_map: pandas.DataFrame
     :param submission_package_dir: directory to save the output manifest
     :type submission_package_dir: str
+    :return: genomic_info table
+    :rtype: pandas.DataFrame
     """
     logger.info("Building genomic_info table")
     logger.info("connecting to database")
@@ -135,4 +137,5 @@ def build_genomic_info_table(
     genomic_info.to_csv(
         f"{submission_package_dir}/genomic_info.csv", index=False
     )
+    breakpoint()
     return genomic_info

--- a/cds/generator/participant/build_manifest.py
+++ b/cds/generator/participant/build_manifest.py
@@ -27,6 +27,19 @@ def order_columns(manifest):
 
 
 def build_participant_table(db_url, participant_list, submission_package_dir):
+    """Build the participant table
+
+    Build the participant manifest
+
+    :param db_url: database url to KF prd postgres
+    :type db_url: str
+    :param participant_list: participant IDs to have in the participant manifest
+    :type participant_list: list
+    :param submission_package_dir: directory to save the output manifest
+    :type submission_package_dir: str
+    :return: participant table
+    :rtype: pandas.DataFrame
+    """
     logger.info("Building participant table")
     logger.info("connecting to database")
     conn = psycopg2.connect(db_url)

--- a/cds/generator/sample/build_manifest.py
+++ b/cds/generator/sample/build_manifest.py
@@ -33,6 +33,19 @@ def order_columns(manifest):
 
 
 def build_sample_table(db_url, sample_list, submission_package_dir):
+    """Build the sample table
+
+    Build the sample manifest
+
+    :param db_url: database url to KF prd postgres
+    :type db_url: str
+    :param sample_list: sample IDs to have in the sample manifest
+    :type sample_list: list
+    :param submission_package_dir: directory to save the output manifest
+    :type submission_package_dir: str
+    :return: sample table
+    :rtype: pandas.DataFrame
+    """
     logger.info("Building sample table")
     logger.info("connecting to database")
     conn = psycopg2.connect(db_url)


### PR DESCRIPTION
# 📝 add docstrings for build_manifest functions

- [ ] closes #xxxx
- [ ] README entry added if new functionality
- [ ] fixup commits are appropriately squashed
- [ ] submission_packet has been regenerated and committed as last commit in this PR

adds docstrings for the `build_[table_name]_table()` functions.
