### PR TITLE
🍱 updated sample manifest after redcap updates

### DIFF
--- a/data/submission_packet/sample.csv
+++ b/data/submission_packet/sample.csv
@@ -520,7 +520,7 @@ BS_52MPKTJH,Tumor,PT_KX84KH6K,tumor,Central Nervous System,4810.0
 BS_531TJYQE,Blood Derived Normal,PT_GKWWWJ0X,normal,Not Reported,432.0
 BS_53CTGDQG,Tumor,PT_3D74J8RZ,tumor,Central Nervous System,9463.0
 BS_53DMYMNP,Blood Derived Normal,PT_KX1QQQRC,normal,Not Reported,4715.0
-BS_53GQKVEX,Tumor,PT_GQZ84ACS,tumor,Central Nervous System,
+BS_53GQKVEX,Tumor,PT_GQZ84ACS,tumor,Central Nervous System,560.0
 BS_53JGYCCZ,Tumor,PT_D9A6G154,tumor,Central Nervous System,4687.0
 BS_53M8PP88,Tumor,PT_NPETR8RY,tumor,Central Nervous System,2338.0
 BS_53TV75NN,Tumor,PT_HVZTF42R,tumor,Central Nervous System,170.0
@@ -865,7 +865,7 @@ BS_8JFMP1T1,Tumor,PT_EYX2CP9F,tumor,Central Nervous System,7023.0
 BS_8MA5B8Y9,Tumor,PT_AP658JQV,tumor,Central Nervous System,5275.0
 BS_8NY9J9NQ,Tumor,PT_JEW5HG4W,tumor,Central Nervous System,5687.0
 BS_8PNA0V6R,Tumor,PT_QQZXYR4M,tumor,Central Nervous System,9490.0
-BS_8PRJTBE1,Blood Derived Normal,PT_1KEER2Q1,normal,Not Reported,
+BS_8PRJTBE1,Blood Derived Normal,PT_1KEER2Q1,normal,Not Reported,3826.0
 BS_8Q2EAYJR,Blood Derived Normal,PT_D13X3N8F,normal,Not Reported,1144.0
 BS_8Q77HZ4R,Tumor,PT_YBJYA2CD,tumor,Central Nervous System,5456.0
 BS_8Q8CAY84,Tumor,PT_596H0BQF,tumor,Central Nervous System,477.0
@@ -2733,7 +2733,7 @@ BS_TRPXB3AV,Tumor,PT_9PDE9KSB,tumor,Central Nervous System,5844.0
 BS_TTRNJ8DJ,Blood Derived Normal,PT_HQ89KPKT,normal,Not Reported,3999.0
 BS_TTVB22NF,Blood Derived Normal,PT_TD6ST5MG,normal,Not Reported,1448.0
 BS_TTZA89Y4,Blood Derived Normal,PT_2VSDT9CK,normal,Not Reported,1956.0
-BS_TV12GQHS,Blood Derived Normal,PT_HEGTYPQJ,normal,Not Reported,6148.0
+BS_TV12GQHS,Blood Derived Normal,PT_HEGTYPQJ,normal,Not Reported,6305.0
 BS_TV5B86ZD,Tumor,PT_9BZETM0M,tumor,Central Nervous System,6523.0
 BS_TV8HD883,Blood Derived Normal,PT_4EDBZRM2,normal,Not Reported,3940.0
 BS_TVH33J9Q,Tumor,PT_M8MDJNZB,tumor,Central Nervous System,3376.0


### PR DESCRIPTION
# 🍱 updated sample manifest after redcap updates

- [ ] closes #xxxx
- [ ] README entry added if new functionality
- [ ] fixup commits are appropriately squashed
- [x] submission_packet has been regenerated and committed as last commit in this PR

see this [asana ticket](https://app.asana.com/0/1201314740969997/1203774488902213/f)- @youngnm and @nicholasvk  made updates after changes were made in redcap for these samples.